### PR TITLE
Improve Dwrote

### DIFF
--- a/src/font_family.rs
+++ b/src/font_family.rs
@@ -11,6 +11,9 @@ use wio::com::ComPtr;
 use super::*;
 use helpers::*;
 
+unsafe impl Send for FontFamily {}
+unsafe impl Sync for FontFamily {}
+
 pub struct FontFamily {
     native: UnsafeCell<ComPtr<IDWriteFontFamily>>,
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -48,6 +48,29 @@ pub fn get_locale_string(strings: &mut ComPtr<IDWriteLocalizedStrings>) -> Strin
     }
 }
 
+pub fn get_nonlocalized_string(strings: &mut ComPtr<IDWriteLocalizedStrings>) -> String {
+    unsafe {
+        let mut index: u32 = 0;
+        let mut exists: BOOL = FALSE;
+        let hr = strings.FindLocaleName((*EN_US_LOCALE).as_ptr(), &mut index, &mut exists);
+        if hr != S_OK || exists == FALSE {
+            // Ultimately fall back to first locale on list
+            index = 0;
+        }
+
+        let mut length: u32 = 0;
+        let hr = strings.GetStringLength(index, &mut length);
+        assert!(hr == 0);
+
+        let mut name: Vec<wchar_t> = Vec::with_capacity(length as usize + 1);
+        let hr = strings.GetString(index, name.as_mut_ptr(), length + 1);
+        assert!(hr == 0);
+        name.set_len(length as usize);
+
+        String::from_utf16(&name).ok().unwrap()
+    }
+}
+
 // ToWide from https://github.com/retep998/wio-rs/blob/master/src/wide.rs
 
 pub trait ToWide {


### PR DESCRIPTION
1. Export missing identifiers.
2. Implement some helpers to get an informational non-localized string.
3. Make Dwrote to work with Rayon.